### PR TITLE
Fix a couple of bugs

### DIFF
--- a/src/balloon.js
+++ b/src/balloon.js
@@ -44,6 +44,8 @@ clippy.Balloon.prototype = {
         var o = this._targetEl.offset();
         var h = this._targetEl.height();
         var w = this._targetEl.width();
+        o.top -= $(window).scrollTop();
+        o.left -= $(window).scrollLeft();
 
         var bH = this._balloon.outerHeight();
         var bW = this._balloon.outerWidth();

--- a/src/balloon.js
+++ b/src/balloon.js
@@ -187,8 +187,11 @@ clippy.Balloon.prototype = {
     },
 
     resume:function () {
-        if (this._addWord)  this._addWord();
-        this._hiding = window.setTimeout($.proxy(this._finishHideBalloon, this), this.CLOSE_BALLOON_DELAY);
+        if (this._addWord) {
+            this._addWord();
+        } else if (!this._hold && !this._hidden) {
+            this._hiding = window.setTimeout($.proxy(this._finishHideBalloon, this), this.CLOSE_BALLOON_DELAY);
+        }
     }
 
 


### PR DESCRIPTION
Hi!

This pull request fixes a few bugs I encountered while using clippy.js:

The first one positions the balloon correctly when the window wasn't scrolled to the top. This happened because the previous code forgot to account for `$.offset()` being relative to the document, but the balloon being positioned relative to the viewport.

The second one makes `.speak`'s `hold` parameter work correctly, by not starting a hide timer in situations where it doesn't make sense to.
