### PR TITLE
Another bugfix: Balloon sometimes doesn't disappear when it should

### DIFF
--- a/src/balloon.js
+++ b/src/balloon.js
@@ -154,6 +154,7 @@ clippy.Balloon.prototype = {
         this._addWord = $.proxy(function () {
             if (!this._active) return;
             if (idx > words.length) {
+                delete this._addWord;
                 this._active = false;
                 if (!this._hold) {
                     complete();


### PR DESCRIPTION
Currently, if a balloon is done adding words but hasn't hidden yet, and you drag it somewhere, it stops the hide timer and is supposed to restart it after the drag. It doesn't, because it assumes it's still in the add-words phase.

Balloon#_addWord is now deleted upon completion, so Balloon#resume can use its existence to decide whether or not to resume the hide timer.
