### PR TITLE
Add a package.json file to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "clippy.js",
+  "version": "1.0.0",
+  "description": "Add Clippy or his friends to any website for instant nostalgia.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/smore-inc/clippy.js.git"
+  },
+  "keywords": [
+    "clippy",
+    "nostalgia",
+    "novelty"
+  ],
+  "author": {
+    "name": "Smore",
+    "url": "https://www.smore.com/"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/smore-inc/clippy.js/issues"
+  },
+  "homepage": "https://www.smore.com/clippy-js"
+}


### PR DESCRIPTION
This PR adds a `package.json` to the root of the repository, thus enabling clippy.js to be loaded via npm.